### PR TITLE
Update NMEA 183, how to recognize RS422 or RS232

### DIFF
--- a/en/nmea-0183-to-usb-converter.md
+++ b/en/nmea-0183-to-usb-converter.md
@@ -5,6 +5,7 @@
 If you have electronics with NMEA 0183 outputs on board (depth, wind, heading...), you will need an USB converter to connect it to OpenPlotter. Additionally, if this converter is bi-directional, you will be able to talk to electronics with NMEA 0183 inputs like the autopilot.
 
 The NMEA 0183 hardware standard uses **RS422** connectors but you may find some devices with **RS232** as well. Find out about what type of connection you need.
+In general, if you have a TX+ and a TX- and/or a RX- and RX+ you have a RS422 interface. If you ave a RX and a TX and a ground you have an RS232 interface.
 
 ## Settings
 


### PR DESCRIPTION
I did some research  how to find if you're device is a RS422 or a RS232.  I found several sites with this generic explanation.
I think it's useful to mention in the documentation. 
If you disagree, please ignore the suggestion.